### PR TITLE
Add status column to report and track skip reasons

### DIFF
--- a/segrega_bot/main.py
+++ b/segrega_bot/main.py
@@ -129,6 +129,7 @@ class Controller:
             result = copy_plan(plan, dst_dir, max_workers=2)
             conflicts = 0
             created_map = {}
+            reason_map = {}
             progress = 0
 
             # Também montamos o manifest (linhas planas)
@@ -150,6 +151,7 @@ class Controller:
                     self.ui.ui_step()
                 for collab, reason in res.get("skipped", []):
                     conflicts += 1
+                    reason_map[(collab, pdf_path)] = reason
                     manifest_rows.append({
                         "source_path": pdf_path,
                         "source_name": src_name,
@@ -174,6 +176,7 @@ class Controller:
                             "collaborator": collab,
                             "source_path": pdf_path,
                             "created_path": created_map.get((collab, pdf_path), ""),
+                            "status": reason_map.get((collab, pdf_path), "created"),
                         })
 
             # -------- Atualiza contadores --------

--- a/segrega_bot/report_writer.py
+++ b/segrega_bot/report_writer.py
@@ -56,21 +56,22 @@ def write_distribution_report(
     # Aba principal
     ws = wb.active
     ws.title = "Relatório de Distribuição"
-    ws.append(["Colaborador", "Documento (origem)", "Arquivo criado", "Caminho do arquivo criado"])
+    ws.append(["Colaborador", "Documento (origem)", "Arquivo criado", "Caminho do arquivo criado", "Status"])
 
     for r in rows:
         collab = r.get("collaborator", "")
         src = r.get("source_path", "")
         dst = r.get("created_path", "")
+        status = r.get("status", "")
 
         src_name = os.path.basename(src) if src else ""
-        created_name = os.path.basename(dst) if dst else "duplicata - ignorada"
+        created_name = os.path.basename(dst) if dst else "-"
         created_path_out = dst if dst else "-"
 
-        ws.append([collab, src_name, created_name, created_path_out])
+        ws.append([collab, src_name, created_name, created_path_out, status])
 
     for collab in not_found_collabs:
-        ws.append([collab, "colaborador não localizado", "-", "-"])
+        ws.append([collab, "colaborador não localizado", "-", "-", ""])
 
     _autosize(ws)
 


### PR DESCRIPTION
## Summary
- capture skip reasons from copy_plan and include them with per-collaborator rows
- add a status field to generated rows and expose it in the distribution report

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c8b3ca3bfc8323843071ff4512de74