### PR TITLE
Handle multiple displays per automaton key

### DIFF
--- a/segrega_bot/search_ac.py
+++ b/segrega_bot/search_ac.py
@@ -1,5 +1,5 @@
 # Aho–Corasick para busca de "palavra inteira" com verificação de fronteiras.
-from typing import Dict, Set, List, Tuple
+from typing import Dict, List, Set, Tuple
 import ahocorasick  # pacote: pyahocorasick
 from util_normalize import is_word_char
 
@@ -9,14 +9,14 @@ def build_automaton(canon_by_display: Dict[str, str]):
     Retorna automaton e também um mapa key->display para atribuição.
     """
     A = ahocorasick.Automaton()
-    key_to_display = {}
+    key_to_display: Dict[str, List[str]] = {}
     for display, key in canon_by_display.items():
         if not key:
             continue
         # Evita duplicar chaves iguais (mesmo nome canônico para pessoas diferentes é raro, mas tratamos)
         if key not in key_to_display:
             A.add_word(key, key)
-            key_to_display[key] = display
+        key_to_display.setdefault(key, []).append(display)
     A.make_automaton()
     return A, key_to_display
 
@@ -35,5 +35,5 @@ def find_keys_in_text(A, text: str) -> Set[str]:
             hits.add(key)
     return hits
 
-def map_keys_to_displays(keys: Set[str], key_to_display: Dict[str, str]) -> Set[str]:
-    return {key_to_display[k] for k in keys if k in key_to_display}
+def map_keys_to_displays(keys: Set[str], key_to_display: Dict[str, List[str]]) -> Set[str]:
+    return {disp for k in keys for disp in key_to_display.get(k, [])}


### PR DESCRIPTION
## Summary
- store all display strings per canonical key when building the Aho-Corasick automaton
- map keys back to every recorded display name when reporting matches

## Testing
- python -m compileall segrega_bot

------
https://chatgpt.com/codex/tasks/task_e_68c8b35a7ccc8323912b613f89908a03