### PR TITLE
Improve copy cancellation and cache validation

### DIFF
--- a/segrega_bot/export_project_to_txt.py
+++ b/segrega_bot/export_project_to_txt.py
@@ -1,6 +1,6 @@
 # export_project_to_txt.py
 # -*- coding: utf-8 -*-
-"""
+r"""
 Converte cada arquivo texto/código do projeto em um .txt com o mesmo conteúdo,
 espelhando a árvore de diretórios. Ignora .venv e __pycache__.
 

--- a/segrega_bot/pdf_reader.py
+++ b/segrega_bot/pdf_reader.py
@@ -1,5 +1,5 @@
 # Extrai texto só das páginas 1–3, com pdfminer e fallback em pypdf.
-from typing import Tuple
+from typing import Tuple, Iterable
 import logging
 
 # silencia pdfminer verboso
@@ -8,53 +8,49 @@ for name in ("pdfminer", "pdfminer.pdfinterp", "pdfminer.pdfpage",
     logging.getLogger(name).setLevel(logging.ERROR)
 
 from pdfminer.high_level import extract_text
-from util_normalize import strip_accents_lower
 import hashlib
 
 def _hash_text(s: str) -> str:
     return hashlib.sha1(s.encode("utf-8", errors="ignore")).hexdigest()
 
-def extract_first_pages_text(path: str, max_pages: int = 3) -> Tuple[str, str]:
-    """
-    Retorna (texto_p1a3, hash_p1a2) – ambos já como string (sem normalizar aqui).
-    """
-    txt = ""
+def _extract_text_for_pages(path: str, page_numbers: Iterable[int]) -> str:
+    pages = list(page_numbers)
+    if not pages:
+        return ""
     try:
-        # page_numbers é 0-based; pegamos até 0,1,2
-        pages = [i for i in range(max_pages)]
         txt = extract_text(path, page_numbers=pages) or ""
     except Exception:
         txt = ""
 
     if len(txt.strip()) < 20:
-        # fallback: pypdf
         try:
             from pypdf import PdfReader
+
             reader = PdfReader(path, strict=False)
+            total = len(reader.pages)
             parts = []
-            for i, page in enumerate(reader.pages[:max_pages]):
-                parts.append(page.extract_text() or "")
+            for idx in pages:
+                if 0 <= idx < total:
+                    parts.append(reader.pages[idx].extract_text() or "")
             txt2 = "\n".join(parts)
             if len(txt2.strip()) > len(txt.strip()):
                 txt = txt2
         except Exception:
             pass
 
-    # Para hash p1–p2, re-extrai só 2 páginas (ou recorta o txt quando possível).
-    txt12 = ""
-    try:
-        txt12 = extract_text(path, page_numbers=[0, 1]) or ""
-    except Exception:
-        # fallback pypdf p/ p1–p2
-        try:
-            from pypdf import PdfReader
-            reader = PdfReader(path, strict=False)
-            parts = []
-            for page in reader.pages[:2]:
-                parts.append(page.extract_text() or "")
-            txt12 = "\n".join(parts)
-        except Exception:
-            txt12 = ""
+    return txt
 
+def extract_first_pages_text(path: str, max_pages: int = 3) -> Tuple[str, str]:
+    """
+    Retorna (texto_p1a3, hash_p1a2) – ambos já como string (sem normalizar aqui).
+    """
+    pages = [i for i in range(max_pages)]
+    txt = _extract_text_for_pages(path, pages)
+    txt12 = _extract_text_for_pages(path, [0, 1])
     h12 = _hash_text(txt12)
     return txt, h12
+
+def extract_first_two_pages_hash(path: str) -> str:
+    """Retorna hash (SHA-1) do texto das duas primeiras páginas."""
+    txt12 = _extract_text_for_pages(path, [0, 1])
+    return _hash_text(txt12)


### PR DESCRIPTION
## Summary
- stop copy operations promptly when cancellation is requested and avoid folder name collisions by normalising collaborator directories uniquely
- validate cached PDFs with a hash of the first two pages via a new helper so restored files are reprocessed when content changes
- mark the export helper docstring as raw to silence the previous compile warning

## Testing
- python -m compileall segrega_bot

------
https://chatgpt.com/codex/tasks/task_e_68c8be25d68c8323b39a0f49abb20274